### PR TITLE
Use linked Github CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- omit in toc -->
 ember-element-query
 ![npm version](https://img.shields.io/npm/v/ember-element-query)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/lolmaus/ember-element-query/CI)
+[![CI](https://github.com/lolmaus/ember-element-query/actions/workflows/ci.yml/badge.svg)](https://github.com/lolmaus/ember-element-query/actions/workflows/ci.yml)
 ==============================================================================
 
 * Use element queries effortlessly on any element or component.


### PR DESCRIPTION
This is the "offical" badge from Github (as copied from their UI). The link is important to get emberobserver.com to recognize this addon has a CI build.